### PR TITLE
Process spatialite geom with null geometry

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from datetime import datetime
 import os
 import tempfile
 import shutil
+import re
 
 # Create FastAPI app
 app = FastAPI(title="BlitzFind API", description="Simple key-value query system with GeoJSON support")
@@ -223,6 +224,23 @@ async def import_spatialite(
                                 geometry = None
                         elif isinstance(geometry_data, dict):
                             geometry = geometry_data
+                    
+                    # If geometry is still null, try to use centre_point as fallback
+                    if geometry is None and 'centre_point' in row_dict:
+                        centre_point = row_dict.get('centre_point')
+                        if centre_point and isinstance(centre_point, str):
+                            # Parse WKT format (e.g., "POINT Z (116.42115915 39.98681646 13.26017761)")
+                            match = re.search(r'POINT\s*(?:Z\s*)?\(([\d.\s-]+)\)', centre_point)
+                            if match:
+                                coords = match.group(1).split()
+                                if len(coords) >= 2:
+                                    geometry = {
+                                        "type": "Point",
+                                        "coordinates": [float(coords[0]), float(coords[1])]
+                                    }
+                                    # Add Z coordinate if present
+                                    if len(coords) >= 3:
+                                        geometry["coordinates"].append(float(coords[2]))
                     
                     # Remove special columns from properties
                     properties = {k: v for k, v in row_dict.items() 


### PR DESCRIPTION
Add fallback to `centre_point` for null geometries in `import_spatialite` to ensure spatial data is always processed.

The `import_spatialite` function previously returned null for the `geometry` field if the primary geometry column was empty, even when a valid WKT string was present in the `centre_point` property. This change ensures that if the main geometry is null, the `centre_point` (e.g., "POINT Z (X Y Z)") is parsed and used as the feature's geometry, preventing loss of spatial information.

---

[Open in Web](https://cursor.com/agents?id=bc-1853e520-fb26-424b-be04-6b38ab40dc35) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1853e520-fb26-424b-be04-6b38ab40dc35) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)